### PR TITLE
change example for array comprehensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ numbers = [ 1, 2, 3 ];
 (Math.sqrt num for num in numbers)
 ```
 
-ES6 equivalent:
+ES7 equivalent:
+
+___Proposed in ES6 but deferred to ES7.___
 
 ```js
 var numbers = [ 1, 2, 3 ];


### PR DESCRIPTION
Array comprehensions are deferred to es7.
Checkout: https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-07/jul-30.md#47-revisit-comprehension-decision-from-last-meeting and https://github.com/lukehoban/es6features/pull/45
