### PR TITLE
use arrow function definition to match CS better

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ES6 equivalent:
 ```js
 // There is no exact equivalent, but there are ternary expressions for common
 // cases like above.
-function grade(student = new Error('student is required')) {
+const grade = (student = new Error('student is required')) => {
    if (student.excellentWork) {
     return 'A+';
   } else if (student.okayStuff) {


### PR DESCRIPTION
in CS we are technically assigning function to grade, while in ES6 equivalent we were creating a function called grade.